### PR TITLE
CRUD authorization for more secure routes 

### DIFF
--- a/__tests__/profiles.test.js
+++ b/__tests__/profiles.test.js
@@ -15,19 +15,19 @@ describe('geo-tone-backend routes', () => {
     pool.end();
   });
 
-  const mockProfile = {
-    userId: '2',
-    username: 'mockusername',
-    bio: 'bio',
-    avatar: 'url',
-  };
-
   const seededProfile = {
     userId: '1',
     username: 'space-lady',
     bio: 'paragon of outsider music, inspiration of tones',
     avatar:
       'https://media2.fdncms.com/portmerc/imager/u/original/19330747/1505926068-music-ttd-paveladyspacelady-terriloewenthal-2.jpg',
+  };
+
+  const mockProfile = {
+    userId: '2',
+    username: 'mockusername',
+    bio: 'bio',
+    avatar: 'url',
   };
 
   const mockUser = {
@@ -39,6 +39,7 @@ describe('geo-tone-backend routes', () => {
   it('creates a profile', async () => {
     await UserService.create(mockUser);
     await agent.post('/api/v1/users/sessions').send(mockUser);
+
     const res = await agent.post('/api/v1/profiles').send(mockProfile);
     expect(res.body).toEqual({ profileId: expect.any(String), ...mockProfile });
   });
@@ -48,6 +49,7 @@ describe('geo-tone-backend routes', () => {
     await UserService.create(mockUser);
     await agent.post('/api/v1/users/sessions').send(mockUser);
     await agent.post('/api/v1/profiles').send(mockProfile);
+
     const res = await agent.get('/api/v1/profiles');
     expect(res.body).toEqual([
       { profileId: expect.any(String), ...seededProfile },
@@ -60,6 +62,7 @@ describe('geo-tone-backend routes', () => {
     const user = await UserService.create(mockUser);
     await agent.post('/api/v1/users/sessions').send(mockUser);
     await agent.post('/api/v1/profiles').send(mockProfile);
+
     const res = await agent.get(`/api/v1/profiles/${user.username}`);
     expect(res.body).toEqual({ profileId: expect.any(String), ...mockProfile });
   });
@@ -69,6 +72,7 @@ describe('geo-tone-backend routes', () => {
     const user = await UserService.create(mockUser);
     await agent.post('/api/v1/users/sessions').send(mockUser);
     await agent.post('/api/v1/profiles').send(mockProfile);
+
     const res = await agent
       .patch(`/api/v1/profiles/${user.username}`)
       .send({ bio: 'updated bio' });
@@ -76,6 +80,21 @@ describe('geo-tone-backend routes', () => {
       profileId: expect.any(String),
       ...mockProfile,
       bio: 'updated bio',
+    });
+  });
+
+  // PROHIBIT USERS FROM EDITING OTHER USER PROFILES
+  it('throws an error when trying to edit another user profile', async () => {
+    await UserService.create(mockUser);
+    await agent.post('/api/v1/users/sessions').send(mockUser);
+    await agent.post('/api/v1/profiles').send(mockProfile);
+
+    const res = await agent
+      .patch(`/api/v1/profiles/${seededProfile.username}`) // Accessing a different user's profile
+      .send({ bio: 'updated bio' });
+    expect(res.body).toEqual({
+      message: 'You are not authorized to modify this user',
+      status: 403,
     });
   });
 });

--- a/__tests__/projects.test.js
+++ b/__tests__/projects.test.js
@@ -115,7 +115,7 @@ describe('geo-tone-backend routes', () => {
     expect(Number(res.text)).toEqual(3);
   });
 
-  // PROHIBIT USERS FROM EDITING OTHER USER PROFILES
+  // PROHIBIT USERS FROM EDITING OTHER USER PROJECTS
   it('throws an error when trying to edit another user project', async () => {
     await UserService.create(mockUser);
     await agent.post('/api/v1/users/sessions').send(mockUser);

--- a/__tests__/projects.test.js
+++ b/__tests__/projects.test.js
@@ -129,4 +129,19 @@ describe('geo-tone-backend routes', () => {
       status: 403,
     });
   });
+
+  // PROHIBIT USERS FROM DELETING OTHER USER PROJECTS
+  it('throws an error when trying to edit another user project', async () => {
+    await UserService.create(mockUser);
+    await agent.post('/api/v1/users/sessions').send(mockUser);
+
+    const res = await agent
+      .delete(`/api/v1/projects/${seededProject.projectId}`)
+      .send({ title: 'editing a project that is not mine' });
+
+    expect(res.body).toEqual({
+      message: 'You are not authorized to modify this project',
+      status: 403,
+    });
+  });
 });

--- a/__tests__/users.test.js
+++ b/__tests__/users.test.js
@@ -64,4 +64,15 @@ describe('user routes test', () => {
     const res = await request(app).get('/api/v1/users/count');
     expect(Number(res.text)).toEqual(2);
   });
+
+  // PROHIBIT USERS FROM DELETING OTHER USER ACCOUNTS
+  it('throws an error when trying to delete another user', async () => {
+    await UserService.create(mockUser);
+    await agent.post('/api/v1/users/sessions').send(mockUser);
+    const res = await agent.delete('/api/v1/users/1');
+    expect(res.body).toEqual({
+      message: 'You are not authorized to modify this user',
+      status: 403,
+    });
+  });
 });

--- a/lib/controllers/profiles.js
+++ b/lib/controllers/profiles.js
@@ -1,5 +1,6 @@
 const { Router } = require('express');
 const authenticate = require('../middleware/authenticate');
+const authorize = require('../middleware/authorize/authorizeProfiles.js');
 const Profile = require('../models/Profile');
 
 module.exports = Router()
@@ -39,7 +40,7 @@ module.exports = Router()
   })
 
   //UPDATES A PROFILE
-  .patch('/:username', authenticate, async (req, res, next) => {
+  .patch('/:username', authenticate, authorize, async (req, res, next) => {
     try {
       const profile = await Profile.updateByUsername(
         req.params.username,

--- a/lib/controllers/projects.js
+++ b/lib/controllers/projects.js
@@ -1,6 +1,6 @@
 const { Router } = require('express');
 const authenticate = require('../middleware/authenticate');
-const authorize = require('../middleware/authorizeProjects');
+const authorize = require('../middleware/authorize/authorizeProjects');
 const Project = require('../models/Project');
 
 module.exports = Router()
@@ -71,7 +71,7 @@ module.exports = Router()
   })
 
   // DELETE PROJECT BY PROJECT ID
-  .delete('/:project_id', authenticate, authorize, async (req, res, next) => {
+  .delete('/:project_id', authenticate, async (req, res, next) => {
     try {
       await Project.deleteByProjectId(req.params.project_id);
       res.send({ message: 'Successfully deleted project' });

--- a/lib/controllers/projects.js
+++ b/lib/controllers/projects.js
@@ -71,7 +71,7 @@ module.exports = Router()
   })
 
   // DELETE PROJECT BY PROJECT ID
-  .delete('/:project_id', authenticate, async (req, res, next) => {
+  .delete('/:project_id', authenticate, authorize, async (req, res, next) => {
     try {
       await Project.deleteByProjectId(req.params.project_id);
       res.send({ message: 'Successfully deleted project' });

--- a/lib/controllers/users.js
+++ b/lib/controllers/users.js
@@ -1,5 +1,6 @@
 const { Router } = require('express');
 const authenticate = require('../middleware/authenticate');
+const authorize = require('../middleware/authorize/authorizeUsers');
 const User = require('../models/User');
 const UserService = require('../services/UserService');
 const ONE_DAY_IN_MS = 1000 * 60 * 60 * 24;
@@ -68,7 +69,7 @@ module.exports = Router()
   })
 
   // DELETE A USER
-  .delete('/:user_id', authenticate, async (req, res, next) => {
+  .delete('/:user_id', authenticate, authorize, async (req, res, next) => {
     try {
       await User.deleteUser(req.params.user_id);
       res

--- a/lib/middleware/authorize/authorizeProfiles.js
+++ b/lib/middleware/authorize/authorizeProfiles.js
@@ -1,0 +1,14 @@
+const Profile = require('../../models/Profile');
+
+module.exports = async (req, res, next) => {
+  try {
+    const { username } = req.user;
+    const profile = await Profile.findProfileByUsername(req.params.username);
+    if (username !== profile.username) throw new Error();
+    next();
+  } catch (error) {
+    error.message = 'You are not authorized to modify this user';
+    error.status = 403;
+    next(error);
+  }
+};

--- a/lib/middleware/authorize/authorizeProjects.js
+++ b/lib/middleware/authorize/authorizeProjects.js
@@ -1,4 +1,4 @@
-const Project = require('../models/Project');
+const Project = require('../../models/Project');
 
 module.exports = async (req, res, next) => {
   try {
@@ -8,6 +8,7 @@ module.exports = async (req, res, next) => {
     next();
   } catch (error) {
     error.message = 'You are not authorized to modify this project';
+    error.status = 403;
     next(error);
   }
 };

--- a/lib/middleware/authorize/authorizeUsers.js
+++ b/lib/middleware/authorize/authorizeUsers.js
@@ -1,4 +1,4 @@
-import User from '../models/User';
+const User = require('../../models/User');
 
 module.exports = async (req, res, next) => {
   try {
@@ -7,7 +7,8 @@ module.exports = async (req, res, next) => {
     if (userId !== user.userId) throw new Error();
     next();
   } catch (error) {
-    error.message = 'You are not authorized to delete this user';
+    error.message = 'You are not authorized to modify this user';
+    error.status = 403;
     next(error);
   }
 };


### PR DESCRIPTION
The files `authorizeUsers.js`, `authorizeProjects.js`, and `authorizeProfiles.js` have moved to `/middleware/authorize/`.

Using the existing authorize middleware written by @forestheims (thank you Forest!), these changes implement and test requirements for user authorization to utilize the following back-end routes:

- `PATCH /api/v1/profiles/:username`
- `PATCH /api/v1/projects/:project_id`
- `DELETE /api/v1/users/:user_id`
- `DELETE /api/v1/projects/:project_id`

Attempts by users who do not match the active session user to access these routes should now respond with a `403` status and an error message.